### PR TITLE
Support OMAPI keys and catch-all options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ See the [dhcp-options(5)](http://linux.die.net/man/5/dhcp-options) man page for 
 | `dhcp_global_routers`             | IP address of the router                                                |
 | `dhcp_global_server_name`         | Server name sent to the client                                          |
 | `dhcp_global_subnet_mask`         | Global subnet mask                                                      |
+| `dhcp_global_omapi_port`          | OMAPI port                                                              |
+| `dhcp_global_omapi_secret`        | OMAPI secret                                                            |
+| `dhcp_global_other_options`       | Array of arbitrary additional global options                            |
 
 (1) This option may be written either as a list (when you have more than one item), or as a string (when you have only one). The following snippet shows an example of both:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@
 
 dhcp_packages_state: "installed"
 dhcp_subnets: []
+dhcp_global_other_options: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,10 +17,19 @@
 - include: apparmor-fix.yml
   when: ansible_os_family == 'Debian'
 
+- name: Set config directory perms
+  file:
+    path: "{{ dhcp_config | dirname }}"
+    state: directory
+    mode: 0755
+
 - name: Install config file
   template:
     src: etc_dhcp_dhcpd.conf.j2
     dest: "{{ dhcp_config }}"
+    owner: root
+    group: root
+    mode: 0644
     validate: 'dhcpd -t -cf %s'
   notify: restart dhcp
   tags: dhcp

--- a/templates/etc_dhcp_dhcpd.conf.j2
+++ b/templates/etc_dhcp_dhcpd.conf.j2
@@ -1,10 +1,18 @@
 # ISC DHCPD configuration -- don't edit manually!
 #
 # {{ ansible_managed }}
-
 #
 # Global options
 #
+{% if dhcp_global_omapi_port is defined %}
+omapi-port {{ dhcp_global_omapi_port }};
+{% endif %}
+{% if dhcp_omapi_secret is defined %}
+key omapi_key {
+    algorithm HMAC-MD5;
+    secret "{{ dhcp_omapi_secret }}";
+};
+{% endif %}
 {% if dhcp_global_authoritative is defined %}
 {{ dhcp_global_authoritative }};
 {% endif %}
@@ -58,14 +66,15 @@ option domain-search {{ dhcp_global_domain_search|join(', ') }};
 {% if dhcp_global_server_name is defined %}
 option server-name "{{ dhcp_global_server_name }}";
 {% endif %}
-
+{% for option in dhcp_global_other_options %}
+option {{ option }};
+{% endfor %}
 {# Template for global option
 {% if dhcp_global_OPT is defined %}
 option OPT {{ dhcp_global_OPT }};
 {% endif %}
 #}
 {% if dhcp_global_classes is defined %}
-
 #
 # Classes
 #
@@ -75,7 +84,6 @@ class "{{ class.name }}" {
   {{ class.match }};
 {% endif %}
 }
-
 {% endfor %}
 {% endif %}
 #
@@ -123,7 +131,6 @@ subnet {{ subnet.ip }} netmask {{ subnet.netmask }} {
 {% if subnet.booting is defined %}
 {{ subnet.booting }} booting;
 {% endif %}
-
 {% if subnet.pools is defined %}
   # Address pool(s)
 {% for pool in subnet.pools %}
@@ -154,14 +161,11 @@ subnet {{ subnet.ip }} netmask {{ subnet.netmask }} {
     deny {{ pool.deny }};
 {% endif %}
   }
-
 {% endfor %}
 {% endif %}
 }
-
 {% endfor %}
 {% if dhcp_hosts is defined %}
-
 {% for host in dhcp_hosts %}
 host {{ host.name }} {
   hardware ethernet {{ host.mac }};


### PR DESCRIPTION
Support for configuring OMAPI and arbitrary options that may not make sense as dedicated variables eases use of the role for dynamic provisioning applications (such as Foreman integration).