### PR TITLE
Allow for a `dhcp_service_state` to be defined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ See the [dhcp-options(5)](http://linux.die.net/man/5/dhcp-options) man page for 
 | `dhcp_global_ntp_servers`         | List of IP addresses of NTP servers                                     |
 | `dhcp_global_routers`             | IP address of the router                                                |
 | `dhcp_global_server_name`         | Server name sent to the client                                          |
+| `dhcp_global_server_state`        | Service state (started, stopped)                                        |
 | `dhcp_global_subnet_mask`         | Global subnet mask                                                      |
 | `dhcp_global_omapi_port`          | OMAPI port                                                              |
 | `dhcp_global_omapi_secret`        | OMAPI secret                                                            |

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,7 @@
 - name: restart dhcp
   service:
     name: "{{ dhcp_service }}"
-    state: restarted
+    state: "{{ (dhcp_global_server_state | default('started') == 'started') | ternary('restarted', 'stopped') }}"
 
 - name: restart apparmor
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,9 +44,9 @@
   notify: restart dhcp
   tags: dhcp
 
-- name: Ensure service is started
+- name: "Ensure service is {{ dhcp_global_server_state | default('started') }}"
   service:
     name: "{{ dhcp_service }}"
-    state: started
+    state: "{{ dhcp_global_server_state | default('started') }}"
     enabled: true
   tags: dhcp


### PR DESCRIPTION
This trivial patch allow defining running state for dhcp server with a `dhcp_service_state` optional variable whose lookup fallback to original values.

HTH, thank you, 