### PR TITLE
Added failover peer parameters to this ansible role.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This file contains al notable changes to the dhcp Ansible role.
 
 This file adheres to the guidelines of [http://keepachangelog.com/](http://keepachangelog.com/). Versioning follows [Semantic Versioning](http://semver.org/).
 
+## 2.1.3 - 2018-08-01
+
+### Added
+
+- New configuration items for failover peer:
+    - `address`, `failover_peer`, `hba`, `load_balance_max_seconds`, `max-balance`, `max-lease-misbalance`, `max-lease-ownership`, `max_response_delay`, `max_unacked_updates`, `mclt`, `min-balance`, `peer_address`, `peer_port`, `port`, `role`, `split`
+
+
 ## 2.1.2 - 2017-11-21
 
 ### Changed
@@ -66,4 +74,3 @@ First release!
 
 - Allow setting some global variables
 - Subnet declarations in YAML
-

--- a/README.md
+++ b/README.md
@@ -83,6 +83,47 @@ dhcp_global_classes:
 
 Class names can be used in the definition of address pools (see below).
 
+(3) This role also supports the definition of a failover peer, e.g.:
+
+```Yaml
+# Failover peer definition
+failover_peer: failover-group
+failover:
+  role: primary # | secondary
+  address: 192.168.56.101
+  port: 647
+  peer_address: 192.168.56.102
+  peer_port: 647
+  max_response_delay: 15
+  max_unacked_updates: 10
+  load_balance_max_seconds: 5
+  split: 255
+  mclt: 3600
+```
+
+An alphabetical list of supported options in a failover declaration:
+
+| Option                	  | Required | Comment                                                               |
+| :---                  	  | :---:    | :--                                                                   |
+| `address`             	  | no       | This server's IP address                                              |
+| `failover_peer`       	  | no       | Name of the configured peer, to be used on a per pool basis           |
+| `hba`                 	  | no       | colon-separated-hex-list                                              |
+| `load_balance_max_seconds`	  | no       | Cutoff after which load balance is disabled (3 to 5 recommended)	     |
+| `max-balance`  		  | no       | Failover pool balance statement					     |
+| `max-lease-misbalance`          | no       | Failover pool balance statement					     |
+| `max-lease-ownership`           | no       | Failover pool balance statement					     |
+| `max_response_delay`  	  | no       | Maximum seconds without contact before engaging failover              |
+| `max_unacked_updates` 	  | no       | Maximum BNDUPD it can send before receiving a BNDACK (10 recommended) |
+| `mclt`                	  | no       | Maximum Client Lead Time                                              |
+| `min-balance`  		  | no       | Failover pool balance statement					     |
+| `peer_address`        	  | no       | Failover peer's IP addres                                             |
+| `peer_port`           	  | no       | This server's port (generally 519/520 or 647/847)                     |
+| `port`                	  | no       | This server's port (generally 519/520 or 647/847)                     |
+| `role`                	  | no       | primary, secondary                                                    |
+| `split`               	  | no       | Load balance split (0-255)                                            |
+
+The failover peer directive has to be in the definition of address pools (see below).
+
 ### Subnet declarations
 
 The role variable `dhcp_subnets` contains a list of dicts, specifying the subnet declarations to be added to the DHCP configuration file. Every subnet declaration should have an `ip` and `netmask`, other options are not mandatory. We start this section with an example, a compelete overview of supported options follows.

--- a/templates/etc_dhcp_dhcpd.conf.j2
+++ b/templates/etc_dhcp_dhcpd.conf.j2
@@ -80,6 +80,66 @@ option {{ option }};
 {% if dhcp_global_includes is defined %}
 
 #
+# DHCP Failover config
+#
+# Notes: In the past couple years, TCP ports 647 (primary) and 847 (peer) have
+# emerged as the standard bindings for DHCP failover. It is worth noting that as
+# recently as 2005, the dhcpd.conf(5) man page used ports 519 and 520 in its
+# failover example, but 647 and 847 look like good choices as of 2008. However,
+# the dhcpd.conf(5) man page says that the primary port and the peer port may be
+# the same number.
+
+{% if failover_peer is defined %}
+failover peer "{{ failover_peer }}" {
+{% if failover.role is defined %}
+   # [ primary | secondary ];
+   {{ failover.role }};
+{% endif %}
+{% if failover.address is defined %}
+  address {{ failover.address }};
+{% endif %}
+{% if failover.port is defined %}
+  port {{ failover.port }};
+{% endif %}
+{% if failover.peer_address is defined %}
+  peer address {{ failover.peer_address }};
+{% endif %}
+{% if failover.peer_port is defined %}
+  peer port {{ failover.peer_port }};
+{% endif %}
+{% if failover.max_response_delay is defined %}
+  max-response-delay {{ failover.max_response_delay }};
+{% endif %}
+{% if failover.max_unacked_updates is defined %}
+  max-unacked-updates {{ failover.max_unacked_updates }};
+{% endif %}
+{% if failover.split is defined %}
+  split {{ failover.split }};
+{% endif %}
+{% if failover.hba is defined %}
+  hba {{ failover.hba }};
+{% endif %}
+{% if failover.mclt is defined %}
+  mclt {{ failover.mclt }};
+{% endif %}
+{% if failover.load_balance_max_seconds is defined %}
+  load balance max seconds {{ failover.load_balance_max_seconds }};
+{% endif %}
+{% if failover.max_lease_misbalance is defined %}
+  max-lease-misbalance {{ failover.max_lease_misbalance }};
+{% endif %}
+{% if failover.max_lease_ownership is defined %}
+  max-lease-ownership {{ failover.max_lease_ownership }};
+{% endif %}
+{% if failover.min_balance is defined %}
+  min-balance {{ failover.min_balance }};
+{% endif %}
+{% if failover.max_balance is defined %}
+  max-balance {{ failover.max_balance }};
+{% endif %}
+}
+{% endif %}
+#
 # Includes
 #
 {% for include in dhcp_global_includes %}
@@ -148,6 +208,10 @@ subnet {{ subnet.ip }} netmask {{ subnet.netmask }} {
   # Address pool(s)
 {% for pool in subnet.pools %}
   pool {
+{% if pool.failover_peer is defined %}
+# This pool has failover, see above for server details
+failover peer "{{ pool.failover_peer }}";
+{% endif %}
 {% if pool.domain_name_servers is defined %}
 {% if pool.domain_name_servers is string %}
     option domain-name-servers {{ pool.domain_name_servers }};


### PR DESCRIPTION
Hi.

I have added all parameters needed to configure support for peer failover, as defined in https://linux.die.net/man/5/dhcpd.conf. I have adhered to the style of the project to the best of my abilities, and I hope it is up to your standards. Anything else you need, let me know.

Kind regards,
  B Cacheira