### PR TITLE
Fix inconsistency with readme for omapi secret

### DIFF
--- a/templates/etc_dhcp_dhcpd.conf.j2
+++ b/templates/etc_dhcp_dhcpd.conf.j2
@@ -8,10 +8,10 @@
 {% if dhcp_global_omapi_port is defined %}
 omapi-port {{ dhcp_global_omapi_port }};
 {% endif %}
-{% if dhcp_omapi_secret is defined %}
+{% if dhcp_global_omapi_secret is defined %}
 key omapi_key {
     algorithm HMAC-MD5;
-    secret "{{ dhcp_omapi_secret }}";
+    secret "{{ dhcp_global_omapi_secret }}";
 };
 {% endif %}
 {% if dhcp_global_authoritative is defined %}


### PR DESCRIPTION
In the README the `dhcp_global_omapi_secret` is defined as such, whereas in the template it is `dhcp_omapi_secret`. 
As it is global it probably does want the global prefix included in the name? However, this would be a breaking change for people's implementations.