### PR TITLE
Support `include` lines for non-existent files in role's files/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ See the [dhcp-options(5)](http://linux.die.net/man/5/dhcp-options) man page for 
 | `dhcp_global_domain_search`       | A list of domain names too be used by the client to locate non-FQDNs(1) |
 | `dhcp_global_filename`            | Filename to request for boot                                            |
 | `dhcp_global_includes`            | List of config files to be included (from `dhcp_config_dir`)            |
+| `dhcp_global_includes_missing`    | Boolean.  Continue if `includes` file(s) missing from role's files/     |
 | `dhcp_global_max_lease_time`      | Maximum lease time in seconds                                           |
 | `dhcp_global_next_server`         | IP for boot server                                                      |
 | `dhcp_global_ntp_servers`         | List of IP addresses of NTP servers                                     |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,4 +4,5 @@
 dhcp_packages_state: "installed"
 dhcp_subnets: []
 dhcp_global_other_options: []
+dhcp_global_includes_missing: False
 dhcp_global_includes: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,7 @@
     src: "{{ item }}"
     dest: "{{ dhcp_config_dir }}/{{ item | basename }}"
   with_items: "{{ dhcp_global_includes }}"
+  ignore_errors: "{{ dhcp_global_includes_missing }}"
   tags: dhcp
 
 - name: Set config directory perms


### PR DESCRIPTION
Add support for creating `include` lines in dhcpd.conf for non-existent files; files not found in role's files/ directory.

It should permit successful configuration of dhcpd.conf with the expectation of another process (role, task, legacy method, etc.) to provide the include file.  