### PR TITLE
update etc_dhcp_dhcpd.conf.j2 to match README

### DIFF
--- a/templates/etc_dhcp_dhcpd.conf.j2
+++ b/templates/etc_dhcp_dhcpd.conf.j2
@@ -74,9 +74,11 @@ option domain-search "{{ dhcp_global_domain_search|join('", "') }}";
 {% if dhcp_global_server_name is defined %}
 option server-name "{{ dhcp_global_server_name }}";
 {% endif %}
+{% if dhcp_global_other_options is defined %}
 {% for option in dhcp_global_other_options %}
 option {{ option }};
 {% endfor %}
+{% endif %}
 {% if dhcp_global_includes is defined %}
 
 #


### PR DESCRIPTION
dhcp_global_other_options is defined as optional in README but no if defined check was present in the j2 template