### PR TITLE
Use list of packages directly instead of a loop

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,9 +10,8 @@
 
 - name: Install packages
   package:
-    pkg: "{{ item }}"
+    name: "{{ dhcp_packages }}"
     state: "{{ dhcp_packages_state }}"
-  with_items: "{{ dhcp_packages }}"
   tags: dhcp
 
 - include_tasks: apparmor-fix.yml


### PR DESCRIPTION
There's no need to loop. If there are more than one packages, they will be installed in one run of the module rather than one run for each package by doing it this way.