### PR TITLE
Added Custom Includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ See the [dhcp-options(5)](http://linux.die.net/man/5/dhcp-options) man page for 
 | `dhcp_global_server_name`         | Server name sent to the client                                         |
 | `dhcp_global_server_state`        | Service state (started, stopped)                                       |
 | `dhcp_global_subnet_mask`         | Global subnet mask                                                     |
+| `dhcp_custom_includes`            | List of jinja config files to be included (from `dhcp_config_dir`)        |
 
 **Remarks**
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,17 @@
   when: ansible_os_family == 'Debian'
   tags: dhcp
 
+- name: Install custom includes
+  template:
+    src: "{{ item }}"
+    dest: "{{ dhcp_config_dir }}/{{ item | basename }}"
+    owner: root
+    group: root
+    mode: 0644
+  with_items: "{{ dhcp_custom_includes }}"
+  when: dhcp_custom_includes is defined
+  tags: dhcp
+
 - name: Install includes
   copy:
     src: "{{ item }}"

--- a/templates/etc_dhcp_dhcpd.conf.j2
+++ b/templates/etc_dhcp_dhcpd.conf.j2
@@ -140,7 +140,7 @@ failover peer "{{ dhcp_global_failover_peer }}" {
 {% endif %}
 }
 {% endif %}
-{% if dhcp_global_includes is defined%}
+{% if dhcp_global_includes is defined %}
 #
 # Includes
 #

--- a/templates/etc_dhcp_dhcpd.conf.j2
+++ b/templates/etc_dhcp_dhcpd.conf.j2
@@ -140,11 +140,20 @@ failover peer "{{ dhcp_global_failover_peer }}" {
 {% endif %}
 }
 {% endif %}
-{% if dhcp_global_includes is defined %}
+{% if dhcp_global_includes is defined%}
 #
 # Includes
 #
 {% for include in dhcp_global_includes %}
+include "{{ dhcp_config_dir }}/{{ include | basename }}";
+{% endfor %}
+{% endif %}
+
+{% if dhcp_custom_includes is defined%}
+#
+# Custom Includes
+#
+{% for include in dhcp_custom_includes %}
 include "{{ dhcp_config_dir }}/{{ include | basename }}";
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
#28 

Heya @bertvv,

I have tried adding a custom include statement that seems to work at the moment and allows the user to be able to use a custom configuration file with templating. 

This PR adds the ability for a user to define a custom template with `dhcp_custom_includes` which is added to the server and included in the main `dhcp.conf` file allowing the user to define custom variables. 

```
vars:
    dhcp_custom_includes:
      - custom-dhcp-config.conf

    dhcp_custom_hosts:
      - name: Juniper1
        mac: 'de:ad:c0:de:ca:fe'
        ip: 192.168.35.160
        options:
          - name: tftp-server-name
            value: 192.168.35.152
          - name: host-name
            value: Juniper1
          - name: NEW_OP.transfer-mode
            value: "https"
          - name: NEW_OP.config-file-name
            value: "/configurations/j1-switch.config"
```

Could you have a look and please let me know if anything is missing or if there is something that could be improved (this is my first PR),

/Alex