### PR TITLE
add notify

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,7 @@
     mode: 0644
   with_items: "{{ dhcp_custom_includes }}"
   when: dhcp_custom_includes is defined
+  notify: restart dhcp
   tags: dhcp
 
 - name: Install includes


### PR DESCRIPTION
I forgot to add a notify statement in there to restart the DHCP service if a new custom configuration has been added or changed. I come across a problem whereby DHCPD was not being restarted after changing Jinja templates etc. 
 