### PR TITLE
Allow to specify listen interfaces on Debian

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ dhcp_apparmor_fix: true
 dhcp_global_includes_missing: false
 dhcp_packages_state: "present"
 dhcp_subnets: []
+dhcp_debian_interfaces_v4: "{{ ansible_default_ipv4.interface }}"

--- a/tasks/default-fix.yml
+++ b/tasks/default-fix.yml
@@ -6,6 +6,6 @@
 - name: Defaults fix | Set a default listening interface
   lineinfile:
     dest: /etc/default/isc-dhcp-server
-    line: 'INTERFACESv4="{{ ansible_default_ipv4.interface }}"'
+    line: 'INTERFACESv4="{{ dhcp_debian_interfaces_v4 }}"'
     regexp: '^INTERFACESv4='
   tags: dhcp


### PR DESCRIPTION
The directive INTERFACESv4 in /etc/default/dhcp may be filled
with listening interfaces for the dhcp server. Hardcoding it to
ansible_default_ipv4.interface prevents the user from specifying a single
interface without extra tasks. It also affects idempotency on
this scenario. This modification adds an extra variable,
dhcp_debian_interfaces_v4, that defaults to ansible_default_ipv4.interface.
This way the behavior is maintained and the user can tweak it
if he wants for Debian OS family.