### PR TITLE
Ranges in pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,16 +162,17 @@ An alphabetical list of supported options in a subnet declaration:
 
 You can specify address pools within a subnet by setting the `pools` options. This allows you to specify a pool of addresses that will be treated differently than another pool of addresses, even on the same network segment or subnet. It is a list of dicts with the following keys, all of which are optional:
 
-| Option                | Comment                                             |
-| :---                  | :---                                                |
-| `allow`               | Specifies which hosts are allowed in this pool(1)   |
-| `default_lease_time`  | The default lease time for this pool                |
-| `deny`                | Specifies which hosts are not allowed in this pool  |
-| `domain_name_servers` | The domain name servers to be used for this pool(1) |
-| `max_lease_time`      | The maximum lease time for this pool                |
-| `min_lease_time`      | The minimum lease time for this pool                |
-| `range_begin`         | The lowest address in this pool                     |
-| `range_end`           | The highest address in this pool                    |
+| Option                | Comment                                                            |
+| :---                  | :---                                                               |
+| `allow`               | Specifies which hosts are allowed in this pool(1)                  |
+| `default_lease_time`  | The default lease time for this pool                               |
+| `deny`                | Specifies which hosts are not allowed in this pool                 |
+| `domain_name_servers` | The domain name servers to be used for this pool(1)                |
+| `max_lease_time`      | The maximum lease time for this pool                               |
+| `min_lease_time`      | The minimum lease time for this pool                               |
+| `range_begin`         | The lowest address in this pool                                    |
+| `range_end`           | The highest address in this pool                                   |
+| `ranges`              | If multiple ranges are needed, they can be specified as a list (2) |
 
 (1) For the `allow` and `deny` fields, the options are enumerated in [dhcpd.conf(5)](http://linux.die.net/man/5/dhcpd.conf), but include:
 

--- a/templates/etc_dhcp_dhcpd.conf.j2
+++ b/templates/etc_dhcp_dhcpd.conf.j2
@@ -245,7 +245,7 @@ option ntp-servers {{ subnet.ntp_servers|join(', ') }};
   pool {
 {% if pool.failover_peer is defined %}
 # This pool has failover, see above for server details
-failover peer "{{ pool.failover_peer }}";
+    failover peer "{{ pool.failover_peer }}";
 {% endif %}
 {% if pool.domain_name_servers is defined %}
 {% if pool.domain_name_servers is string %}
@@ -265,6 +265,11 @@ failover peer "{{ pool.failover_peer }}";
 {% endif %}
 {% if pool.range_begin is defined and pool.range_end is defined %}
     range {{ pool.range_begin }} {{ pool.range_end }};
+{% endif %}
+{% if pool.ranges is defined %}
+{% for range in pool.ranges %}
+    range {{ range.begin }} {{ range.end }};
+{% endfor %}
 {% endif %}
 {% if pool.allow is defined %}
     allow {{ pool.allow }};


### PR DESCRIPTION
Current implementation only will template range_begin and range_end inside pool definition. This modification allow to define ranges in the same way as in subnets.
