### PR TITLE
Add support for RHEL8 and it's derivatives...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Change log
 
-This file contains al notable changes to the dhcp Ansible role.
+This file contains all notable changes to the dhcp Ansible role.
 
 This file adheres to the guidelines of [http://keepachangelog.com/](http://keepachangelog.com/). Versioning follows [Semantic Versioning](http://semver.org/).
+
+## 3.0.3 - 2020-05-06
+
+### Added
+
+- (GH-40) Added support for RHEL 8, and it's derivatives. (credit: [Stuart Knight](https://github.com/blofeldthefish))
 
 ## 3.0.2 - 2019-08-29
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
     - name: Fedora
       versions:
         - 29

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,7 +2,7 @@
 ---
 
 dhcp_packages:
-  - dhcp
+  - "{{ ( ansible_distribution_major_version == '8' ) | ternary( 'dhcp-server', 'dhcp' ) }}"
 
 dhcp_config_dir: /etc/dhcp
 


### PR DESCRIPTION
The DHCP package was renamed in RHEL8, and so this fix takes that into account, when sourcing variables.