### PR TITLE
J2 extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,11 +216,11 @@ Setting the variable `dhcp_pxeboot_server`, will redirect PXE clients to the spe
 
 ### Custom Includes
 
-Setting the variable `dhcp_custom_inludes` to a jinja template will allow custom configurations to be used which will subsiquently be included into the `dhcpd.conf` file. 
+Setting the variable `dhcp_custom_inludes` to a jinja template will allow custom configurations to be used which will subsiquently be included into the `dhcpd.conf` file. If the template file name has the `.j2` extension it will be removed from the destination file name, else it will preserve the template file name in the destination.
 
 ```Yaml
 dhcp_custom_includes:
-  - custom-dhcp-config.conf
+  - custom-dhcp-config.conf.j2
 ```
 
 You can create your own variables to use within the template allowing for total flexibility. To avoid variable conflicts make sure that you use variables that are not referenced within this role as this will duplicate configuration in multiple `.conf` files.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Setting the variable `dhcp_pxeboot_server`, will redirect PXE clients to the spe
 
 ### Custom Includes
 
-Setting the variable `dhcp_custom_inludes` to a jinja template will allow custom configurations to be used which will subsiquently be included into the `dhcpd.conf` file. If the template file name has the `.j2` extension it will be removed from the destination file name, else it will preserve the template file name in the destination.
+Setting the variable `dhcp_custom_inludes` to a jinja template will allow custom configurations to be used which will subsequently be included into the `dhcpd.conf` file. If the template file name has the `.j2` extension it will be removed from the destination file name, else it will preserve the template file name in the destination.
 
 ```Yaml
 dhcp_custom_includes:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,10 @@
 - name: Install custom includes
   template:
     src: "{{ item }}"
-    dest: "{{ dhcp_config_dir }}/{{ item | basename }}"
+    dest: >-
+      {{ dhcp_config_dir + '/' + (item | basename)
+      if (item | basename | splitext | last) != '.j2' else
+      dhcp_config_dir + '/' + (item | basename | splitext | first) }}
     owner: root
     group: root
     mode: 0644

--- a/templates/etc_dhcp_dhcpd.conf.j2
+++ b/templates/etc_dhcp_dhcpd.conf.j2
@@ -154,7 +154,9 @@ include "{{ dhcp_config_dir }}/{{ include | basename }}";
 # Custom Includes
 #
 {% for include in dhcp_custom_includes %}
-include "{{ dhcp_config_dir }}/{{ include | basename }}";
+include "{{ dhcp_config_dir + '/' + (include | basename)
+  if (include | basename | splitext | last) != '.j2' else
+  dhcp_config_dir + '/' + (include | basename | splitext | first) }}";
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
This is more like a personal taste so I totally understand if you dislike, disagree or do not want to use it.

That being said, the first time I read the documentation for the custom includes my attention was caught by the absence of the .j2 extension in the template file name. The pull request modifies so if there is a .j2 extension in the template file name it will be removed from the destination file name. To maintain compatibility, if there is no such extension, the template file name will be preserved in the destination file name.

Hope you enjoy it.