### PR TITLE
J2 inc perms

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,8 +25,8 @@
 
 - name: Install custom includes
   template:
-    src: "{{ item }}"
-    dest: "{{ dhcp_config_dir }}/{{ ( item | basename ).split('.j2')[0] }}"
+    src: "{{ item.0 }}"
+    dest: "{{ dhcp_config_dir }}/{{ ( item.0 | basename ).split('.j2')[0] }}"
     owner: root
     group: root
     mode: "{{ item.1 | default('0644') }}"


### PR DESCRIPTION
In the case the case that the PR https://github.com/bertvv/ansible-role-dhcp/pull/45 is accepted, this allow to set permissions for custom includes.

It is possible that some sensitive information to be put in the
custom include file, like a DNS updater secret key. In order
to guarantee apropriate permissions for the destination file
an extra variable is defined, dhcp_custom_includes_modes. The
filter zip_longest is used in conjunction with dhcp_custom_includes.
The default mode if not specified is 0644. A more elegant approach
would be to transform the dhcp_custom_includes variable in a
list of dicts instead of a list of strings. But that way would
break compatibility with previous versions.