### PR TITLE
Allow to set permissions for custom includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ See the [dhcp-options(5)](http://linux.die.net/man/5/dhcp-options) man page for 
 | `dhcp_global_server_state`        | Service state (started, stopped)                                       |
 | `dhcp_global_subnet_mask`         | Global subnet mask                                                     |
 | `dhcp_custom_includes`            | List of jinja config files to be included (from `dhcp_config_dir`)     |
+| `dhcp_custom_includes_modes`      | List of modes for the destination custom config file                   |
 
 **Remarks**
 
@@ -222,6 +223,13 @@ Setting the variable `dhcp_custom_inludes` to a jinja template will allow custom
 ```Yaml
 dhcp_custom_includes:
   - custom-dhcp-config.conf
+```
+
+The default mode for the destination custom config file is 0644. To modify this set the variable `dhcp_custom_includes_modes`. The zip_longest filter will be used in conjunction with `dhcp_custom_includes` variable.
+
+```Yaml
+dhcp_custom_includes_modes:
+  - '0600'
 ```
 
 You can create your own variables to use within the template allowing for total flexibility. To avoid variable conflicts make sure that you use variables that are not referenced within this role as this will duplicate configuration in multiple `.conf` files.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,12 +25,12 @@
 
 - name: Install custom includes
   template:
-    src: "{{ item }}"
-    dest: "{{ dhcp_config_dir }}/{{ item | basename }}"
+    src: "{{ item.0 }}"
+    dest: "{{ dhcp_config_dir }}/{{ item.0 | basename }}"
     owner: root
     group: root
-    mode: 0644
-  with_items: "{{ dhcp_custom_includes }}"
+    mode: "{{ item.1 | default('0644') }}"
+  loop: "{{ dhcp_custom_includes | zip_longest(dhcp_custom_includes_modes | default([])) | list }}"
   when: dhcp_custom_includes is defined
   notify: restart dhcp
   tags: dhcp


### PR DESCRIPTION
In the case the case that the PR https://github.com/bertvv/ansible-role-dhcp/pull/45 is **NOT** accepted, this allow to set permissions for custom includes.

It is possible that some sensitive information to be put in the
custom include file, like a DNS updater secret key. In order
to guarantee apropriate permissions for the destination file
an extra variable is defined, dhcp_custom_includes_modes. The
filter zip_longest is used in conjunction with dhcp_custom_includes.
The default mode if not specified is 0644. A more elegant approach
would be to transform the dhcp_custom_includes variable in a
list of dicts instead of a list of strings. But that way would
break compatibility with previous versions.