### PR TITLE
OPS-2133 Add DHCP Monitoring module

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,12 @@
     state: "{{ dhcp_packages_state }}"
   tags: dhcp
 
+- name: Install pip DHCPMonitor  module
+  pip:
+    name: isc_dhcp_leases
+  tags:
+    - package
+
 - include_tasks: apparmor-fix.yml
   when: ansible_os_family == 'Debian' and dhcp_apparmor_fix|bool
   tags: dhcp

--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -3,6 +3,8 @@
 
 dhcp_packages:
   - dhcp
+  - python
+  - py-pip
 
 dhcp_config_dir: /etc/dhcp
 


### PR DESCRIPTION
Adds a module to easily parse the lease file.