### PR TITLE
Set the host-name option to the hostname whenever a host is given

### DIFF
--- a/templates/etc_dhcp_dhcpd.conf.j2
+++ b/templates/etc_dhcp_dhcpd.conf.j2
@@ -236,6 +236,7 @@ option ntp-servers {{ subnet.ntp_servers|join(', ') }};
   host {{ host.name }} {
     hardware ethernet {{ host.mac }};
     fixed-address {{ host.ip }};
+    option host-name "{{ host.name }}";
   }
 {% endfor %}
 {% endif %}
@@ -293,6 +294,7 @@ host {{ host.name | replace (" ","_") | replace ("'","_") | replace (":","_") }}
 {% if host.ip is defined %}
   fixed-address {{ host.ip }};
 {% endif %}
+  option host-name "{{ host.name }}";
 }
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
A small addition, also setting the host-name option pushed through dhcp to the name of the host