### PR TITLE
added support for generic subnet options

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ An alphabetical list of supported options in a subnet declaration:
 | `routers`             | no       | IP address of the gateway for this subnet                             |
 | `server_name`         | no       | Server name sent to the client                                        |
 | `subnet_mask`         | no       | Overrides the `netmask` of the subnet declaration                     |
+| `options`             | no       | A dict of options to add to this subnet                               |
 
 You can specify address pools within a subnet by setting the `pools` options. This allows you to specify a pool of addresses that will be treated differently than another pool of addresses, even on the same network segment or subnet. It is a list of dicts with the following keys, all of which are optional:
 

--- a/templates/etc_dhcp_dhcpd.conf.j2
+++ b/templates/etc_dhcp_dhcpd.conf.j2
@@ -234,6 +234,11 @@ option ntp-servers {{ subnet.ntp_servers|join(', ') }};
 {% if subnet.booting is defined %}
 {{ subnet.booting }} booting;
 {% endif %}
+{% if subnet.options is defined %}
+{% for opt in subnet.options %}
+  option {{ opt }} {{ subnet.options[opt] }};
+{% endfor %}
+{% endif %}
 {% if subnet.hosts is defined %}
 {% for host in subnet.hosts %}
   host {{ host.name }} {


### PR DESCRIPTION
This PR gives the ability to add any generic options that are not already handled (such as domain-name) to subnets.