### PR TITLE
Add Debian "d-i" declaration to boot install

### DIFF
--- a/templates/etc_dhcp_dhcpd.conf.j2
+++ b/templates/etc_dhcp_dhcpd.conf.j2
@@ -317,10 +317,10 @@ host {{ host.name | replace (" ","_") | replace ("'","_") | replace (":","_") }}
 {% endif %}
 {# Debian "d-i" declaration to boot install #}
 {%- for subnet in dhcp_subnets %}
-{% set network = (subnet.ip + '/' + subnet.netmask)  | ansible.netcommon.ipaddr('network/prefix') %}
-{% if subnet.next_server is defined 
-and host.ip is defined 
-and host.ip  | ansible.netcommon.ipaddr(network) | ansible.netcommon.ipaddr('bool') %}
+{% set network = (subnet.ip + '/' + subnet.netmask) | ansible.netcommon.ipaddr('network/prefix') %}
+{% if subnet.next_server is defined
+and host.ip is defined
+and host.ip | ansible.netcommon.ipaddr(network) %}
   if substring (option vendor-class-identifier, 0, 3) = "d-i" {
     filename "tftp://{{ subnet.next_server }}/pxelinux.cfg/01-{{ host.mac |replace(':', '-') | lower }}.cfg";
   }

--- a/templates/etc_dhcp_dhcpd.conf.j2
+++ b/templates/etc_dhcp_dhcpd.conf.j2
@@ -79,6 +79,9 @@ option domain-search "{{ dhcp_global_domain_search|join('", "') }}";
 option {{ option }};
 {% endfor %}
 {% endif %}
+{% if dhcp_global_pxe_arch is defined and dhcp_global_pxe_arch %}
+option arch code 93 = unsigned integer 16; # RFC4578
+{% endif %}
 {% if dhcp_global_failover_peer is defined %}
 
 #
@@ -225,8 +228,16 @@ subnet {{ subnet.ip }} netmask {{ subnet.netmask }} {
 {% if subnet.next_server is defined %}
   next-server {{ subnet.next_server }};
 {% endif %}
-{% if subnet.filename is defined %}
+{% if subnet.filename is defined and subnet.filename64 is defined %}
+  if option arch = 00:07 {
+    filename "{{ subnet.filename64 }}";
+  } else {
+    filename "{{ subnet.filename }}";
+  }
+{% elif subnet.filename is defined %}
   filename "{{ subnet.filename }}";
+{% elif subnet.filename64 is defined %}
+  filename "{{ subnet.filename64 }}";
 {% endif %}
 {% if subnet.bootp is defined %}
 {{ subnet.bootp }} bootp;
@@ -318,13 +329,11 @@ and host.ip  | ansible.netcommon.ipaddr(network) | ansible.netcommon.ipaddr('boo
 }
 {% endfor %}
 {% endif %}
-{% if dhcp_pxeboot_server is defined %}
+{% if dhcp_pxeboot_server is defined and dhcp_pxeboot_server %}
 
 #
 # PXEBoot server settings
 #
-option arch code 93 = unsigned integer 16; # RFC4578
-
 class "pxeclients" {
   match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
   next-server {{ dhcp_pxeboot_server }};

--- a/templates/etc_dhcp_dhcpd.conf.j2
+++ b/templates/etc_dhcp_dhcpd.conf.j2
@@ -306,10 +306,10 @@ host {{ host.name | replace (" ","_") | replace ("'","_") | replace (":","_") }}
 {% endif %}
 {# Debian "d-i" declaration to boot install #}
 {%- for subnet in dhcp_subnets %}
-{% set network = (subnet.ip + '/' + subnet.netmask)  | ipaddr('network/prefix') %}
+{% set network = (subnet.ip + '/' + subnet.netmask)  | ansible.netcommon.ipaddr('network/prefix') %}
 {% if subnet.next_server is defined 
 and host.ip is defined 
-and host.ip  | ipaddr(network) | ipaddr('bool') %}
+and host.ip  | ansible.netcommon.ipaddr(network) | ansible.netcommon.ipaddr('bool') %}
   if substring (option vendor-class-identifier, 0, 3) = "d-i" {
     filename "tftp://{{ subnet.next_server }}/pxelinux.cfg/01-{{ host.mac |replace(':', '-') | lower }}.cfg";
   }

--- a/templates/etc_dhcp_dhcpd.conf.j2
+++ b/templates/etc_dhcp_dhcpd.conf.j2
@@ -304,6 +304,17 @@ host {{ host.name | replace (" ","_") | replace ("'","_") | replace (":","_") }}
 {% if host.hostname is defined %}
   option host-name "{{ host.hostname }}";
 {% endif %}
+{# Debian "d-i" declaration to boot install #}
+{%- for subnet in dhcp_subnets %}
+{% set network = (subnet.ip + '/' + subnet.netmask)  | ipaddr('network/prefix') %}
+{% if subnet.next_server is defined 
+and host.ip is defined 
+and host.ip  | ipaddr(network) | ipaddr('bool') %}
+  if substring (option vendor-class-identifier, 0, 3) = "d-i" {
+    filename "tftp://{{ subnet.next_server }}/pxelinux.cfg/01-{{ host.mac |replace(':', '-') | lower }}.cfg";
+  }
+{% endif %}
+{% endfor %}
 }
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
In order to do an automatic installation of a Debian distro via a PXE boot, it is necessary to declare a config file named :

```<tftp server>:///pxelinux.cfg/01-<mac address>.cfg``` 

Regard,

Jb