### PR TITLE
fix ansible-lint warning : Use FQCN for builtin actions

### DIFF
--- a/tasks/apparmor-fix.yml
+++ b/tasks/apparmor-fix.yml
@@ -4,13 +4,13 @@
 ---
 
 - name: AppArmor fix | Check if policy file exists
-  stat:
+  ansible.builtin.stat:
     path: "{{ dhcp_apparmor_policy }}"
   register: apparmor_policyfile
   tags: dhcp
 
 - name: AppArmor fix | Ensure dhcpd can acces temp config file for validation (1/2)
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: "{{ dhcp_apparmor_policy }}"
     line: '  capability dac_override,'
     insertafter: '  capability setuid,'
@@ -22,7 +22,7 @@
   tags: dhcp
 
 - name: AppArmor fix | Ensure dhcpd can acces temp config file for validation (2/2)
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: "{{ dhcp_apparmor_policy }}"
     line: '  /home/*/.ansible/** r,'
     insertbefore: '.*/etc/dhcp/ r,'
@@ -35,4 +35,4 @@
   tags: dhcp
 
 - name: AppArmor fix | Force running handlers now
-  meta: flush_handlers
+  ansible.builtin.meta: flush_handlers

--- a/tasks/default-fix.yml
+++ b/tasks/default-fix.yml
@@ -4,7 +4,7 @@
 ---
 
 - name: Defaults fix | Set a default listening interface
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: /etc/default/isc-dhcp-server
     line: 'INTERFACESv4="{{ dhcp_interfaces | default(ansible_default_ipv4.interface) }}"'
     regexp: '^INTERFACESv4='

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 ---
 
 - name: Load distro-specific variables
-  include_vars: "{{ item }}"
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
@@ -10,23 +10,23 @@
   tags: dhcp
 
 - name: Install packages
-  package:
+  ansible.builtin.package:
     name: "{{ dhcp_packages }}"
     state: "{{ dhcp_packages_state }}"
   tags: dhcp
 
 - name: Run AppArmor fix when appropriate
-  include_tasks: apparmor-fix.yml
+  ansible.builtin.include_tasks: apparmor-fix.yml
   when: ansible_os_family == 'Debian' and dhcp_apparmor_fix|bool
   tags: dhcp
 
 - name: Set default listening interface on Debian and derivatives
-  include_tasks: default-fix.yml
+  ansible.builtin.include_tasks: default-fix.yml
   when: ansible_os_family == 'Debian'
   tags: dhcp
 
 - name: Install custom includes
-  template:
+  ansible.builtin.template:
     src: "{{ item.0 }}"
     dest: "{{ dhcp_config_dir }}/{{ ( item.0 | basename ).split('.j2')[0] }}"
     owner: root
@@ -38,7 +38,7 @@
   tags: dhcp
 
 - name: Install includes
-  copy:
+  ansible.builtin.copy:
     src: "{{ item }}"
     dest: "{{ dhcp_config_dir }}/{{ item | basename }}"
     owner: root
@@ -50,14 +50,14 @@
   tags: dhcp
 
 - name: Set config directory perms
-  file:
+  ansible.builtin.file:
     path: "{{ dhcp_config | dirname }}"
     state: directory
     mode: '0755'
   tags: dhcp
 
 - name: Install config file
-  template:
+  ansible.builtin.template:
     src: etc_dhcp_dhcpd.conf.j2
     dest: "{{ dhcp_config }}"
     owner: root
@@ -67,7 +67,7 @@
   tags: dhcp
 
 - name: "Ensure service is {{ dhcp_global_server_state | default('started') }}"
-  service:
+  ansible.builtin.service:
     name: "{{ dhcp_service }}"
     state: "{{ dhcp_global_server_state | default('started') }}"
     enabled: true


### PR DESCRIPTION
trivial change