### PR TITLE
Add OpenBSD support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,8 @@
   package:
     name: "{{ dhcp_packages }}"
     state: "{{ dhcp_packages_state }}"
+  # System component on OpenBSD
+  when: ansible_os_family != 'OpenBSD'
   tags: dhcp
 
 - name: Run AppArmor fix when appropriate
@@ -62,7 +64,7 @@
     dest: "{{ dhcp_config }}"
     owner: root
     mode: '0644'
-    validate: 'dhcpd -t -cf %s'
+    validate: '{{ dhcp_validate_cmd }} %s'
   notify: Restart DHCP
   tags: dhcp
 

--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -9,3 +9,5 @@ dhcp_config_dir: /etc/dhcp
 dhcp_config: /etc/dhcp/dhcpd.conf
 
 dhcp_service: dhcpd
+
+dhcp_validate_cmd: "dhcpd -t -cf"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -11,3 +11,5 @@ dhcp_config: /etc/dhcp/dhcpd.conf
 dhcp_service: isc-dhcp-server
 
 dhcp_apparmor_policy: /etc/apparmor.d/usr.sbin.dhcpd
+
+dhcp_validate_cmd: "dhcpd -t -cf"

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -9,3 +9,5 @@ dhcp_config_dir: /usr/local/etc/
 dhcp_config: /usr/local/etc/dhcpd.conf
 
 dhcp_service: isc-dhcpd
+
+dhcp_validate_cmd: "dhcpd -t -cf"

--- a/vars/OpenBSD.yml
+++ b/vars/OpenBSD.yml
@@ -1,0 +1,13 @@
+# roles/dhcp/vars/OpenBSD.yml
+---
+
+dhcp_packages:
+  - dhcpd
+
+dhcp_config_dir: /etc/
+
+dhcp_config: /etc/dhcpd.conf
+
+dhcp_service: dhcpd
+
+dhcp_validate_cmd: "dhcpd -n -c"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -9,3 +9,5 @@ dhcp_config_dir: /etc/dhcp
 dhcp_config: /etc/dhcp/dhcpd.conf
 
 dhcp_service: dhcpd
+
+dhcp_validate_cmd: "dhcpd -t -cf"


### PR DESCRIPTION
- introduce dhcp_validate_cmd
  - OpenBSD's check is different so make it configurable
- Do not try to install package on OpenBSD. dhcpd(1) is a base component in OpenBSD.